### PR TITLE
declare location for __progname when it's not supported

### DIFF
--- a/main.c
+++ b/main.c
@@ -41,6 +41,10 @@
 #include <unistd.h>
 #include "defs.h"
 
+#ifndef HAVE_PROGNAME
+char *__progname;
+#endif
+
 char dflag;
 char lflag;
 char rflag;


### PR DESCRIPTION
The configure script checks whether the toolchain supports __progname and will define `HAVE_PROGNAME` accordingly.  `__progname` is also declared by yacc source in "defs.h" and "portable.h" (these are redundant) but they are declared as `extern char *__progname`.  When __progname is not supported, yacc doesn't include a non-extern definition which means compiling yacc will fail to link.  This change defines __progname inside main.c when it's not supported by the toolchain.